### PR TITLE
Fixed data lost on Non-Blocking send & protected UDP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## Current
+## Release 0.4.6
 - Fixed lost decoding memory at disconnection.
 - Fixed issue in send methods where sometimes data is lost.
 - Fixed lost fragmented UDP.
   Before this change, a huge UDP message could be sent without respect the MTU size, now it panics.
+- Fixed rare issue of EventQueue dropping when the sender send and event and the receiver
+  is already removed.
 
 ## Release 0.4.5
 - Fixed enconding issue related several messages in the same data chunk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current
 - Fixed lost decoding memory at disconnection.
+- Fixed issue in send methods where sometimes data is lost.
+- Fixed lost fragmented UDP.
+  Before this change, a huge UDP message could be sent without respect the MTU size, now it panics.
 
 ## Release 0.4.5
 - Fixed enconding issue related several messages in the same data chunk.

--- a/src/network.rs
+++ b/src/network.rs
@@ -12,7 +12,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration};
 use std::io::{self};
 
-pub use crate::network_adapter::{Endpoint};
+pub use crate::network_adapter::{Endpoint, MAX_UDP_LEN};
 
 const NETWORK_SAMPLING_TIMEOUT: u64 = 50; //ms
 const INPUT_BUFFER_SIZE: usize = 65536;

--- a/src/network_adapter.rs
+++ b/src/network_adapter.rs
@@ -281,7 +281,7 @@ impl Controller {
             // In this context, Other(code: 90) means that UDP packet that exceeds MTU size.
             // Since this is managing by MAX_UDP_LEN. It should not ocurr.
             Err(ref err) if err.kind() == io::ErrorKind::Other => {
-                Err(err).expect(&format!("UDP MTU <= {}", MAX_UDP_LEN))
+                Err(err).unwrap_or_else(|_| panic!("UDP MTU <= {}", MAX_UDP_LEN))
             }
             // No more errors should happens in UDP.
             Err(err) => Err(err).expect("To not occur"),


### PR DESCRIPTION
- Fixed non-blocking data lost by active waiting.
- Protected from long UDP packets. 
- Added integration tests.
- Updated v0.4.6