### PR TITLE
Fixed leak memory. Better timer events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release 0.5.1
+- Fixed a leak memory with timer events.
+- Improved timer events accuracy.
+
 ## Release 0.5.0
 - Renamed: `receive_event_timeout` to `receive_timeout`.
 - Renaded: `NetworkManager` to `Network`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,22 +133,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -159,7 +149,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -170,21 +160,10 @@ checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -287,12 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,11 +282,11 @@ dependencies = [
 
 [[package]]
 name = "message-io"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bincode",
  "criterion",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "lazy_static",
  "log",
  "mio",
@@ -438,9 +411,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message-io"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 mio = { version = "0.7", features = ["os-poll", "tcp", "udp"] }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.1"
-crossbeam-channel = "0.4.2"
+crossbeam-channel = "0.5"
 log = "0.4"
 net2 = "0.2.34"
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,19 +1,14 @@
 use crossbeam_channel::{self, Sender, Receiver, select};
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
-use std::time::Duration;
-use std::thread::{self, JoinHandle};
-use std::collections::{HashMap};
-
-const TIMER_SAMPLING_CHECK: u64 = 50; //ms
+use std::time::{Instant, Duration};
+use std::collections::{BTreeMap};
 
 pub struct EventQueue<E> {
     event_sender: EventSender<E>, // Should be before receiver in order to drop first.
     receiver: Receiver<E>,
+    timer_receiver: Receiver<(Instant, E)>,
     priority_receiver: Receiver<E>,
+    timers: BTreeMap<Instant, E>,
 }
 
 impl<E> EventQueue<E>
@@ -22,11 +17,14 @@ where E: Send + 'static
     /// Creates a new event queue for generic incoming events.
     pub fn new() -> EventQueue<E> {
         let (sender, receiver) = crossbeam_channel::unbounded();
+        let (timer_sender, timer_receiver) = crossbeam_channel::unbounded();
         let (priority_sender, priority_receiver) = crossbeam_channel::unbounded();
         EventQueue {
+            event_sender: EventSender::new(sender, timer_sender, priority_sender),
             receiver,
+            timer_receiver,
             priority_receiver,
-            event_sender: EventSender::new(sender, priority_sender),
+            timers: BTreeMap::new(),
         }
     }
 
@@ -37,38 +35,73 @@ where E: Send + 'static
         &mut self.event_sender
     }
 
+    fn enque_timers(&mut self) {
+        for timer in self.timer_receiver.try_iter() {
+            self.timers.insert(timer.0, timer.1);
+        }
+    }
+
     /// Blocks the current thread until an event is received by this queue.
     pub fn receive(&mut self) -> E {
-        let event = if !self.priority_receiver.is_empty() {
-            self.priority_receiver.recv()
+        self.enque_timers();
+        // Since EventQueue always has a sender attribute,
+        // any call to receive() always has a living sender in that time
+        // and the channel never can be considered disconnected.
+        if !self.priority_receiver.is_empty() {
+            self.priority_receiver.recv().unwrap()
+        }
+        else if self.timers.is_empty() {
+            select! {
+                recv(self.receiver) -> event => event.unwrap(),
+                recv(self.priority_receiver) -> event => event.unwrap(),
+            }
         }
         else {
-            select! {
-                recv(self.receiver) -> event => event,
-                recv(self.priority_receiver) -> event => event,
+            let next_instant = *self.timers.iter().next().unwrap().0;
+            if next_instant <= Instant::now() {
+                self.timers.remove(&next_instant).unwrap()
             }
-        };
-
-        match event {
-            Ok(event) => event,
-            // Since EventQueue always has a sender attribute,
-            // any call to receive() always has a living sender in that time
-            // and the channel never can be considered disconnected.
-            Err(_) => unreachable!(),
+            else {
+                select! {
+                    recv(self.receiver) -> event => event.unwrap(),
+                    recv(self.priority_receiver) -> event => event.unwrap(),
+                    recv(crossbeam_channel::at(next_instant)) -> _ => {
+                        self.timers.remove(&next_instant).unwrap()
+                    }
+                }
+            }
         }
     }
 
     /// Blocks the current thread until an event is received by this queue or timeout is exceeded.
     /// If timeout is reached a None is returned, otherwise the event is returned.
     pub fn receive_timeout(&mut self, timeout: Duration) -> Option<E> {
+        self.enque_timers();
+
         if !self.priority_receiver.is_empty() {
             Some(self.priority_receiver.recv().unwrap())
         }
-        else {
+        else if self.timers.is_empty() {
             select! {
                 recv(self.receiver) -> event => Some(event.unwrap()),
                 recv(self.priority_receiver) -> event => Some(event.unwrap()),
                 default(timeout) => None
+            }
+        }
+        else {
+            let next_instant = *self.timers.iter().next().unwrap().0;
+            if next_instant <= Instant::now() {
+                self.timers.remove(&next_instant)
+            }
+            else {
+                select! {
+                    recv(self.receiver) -> event => Some(event.unwrap()),
+                    recv(self.priority_receiver) -> event => Some(event.unwrap()),
+                    recv(crossbeam_channel::at(next_instant)) -> _ => {
+                        self.timers.remove(&next_instant)
+                    }
+                    default(timeout) => None
+                }
             }
         }
     }
@@ -84,10 +117,8 @@ where E: Send + 'static
 
 pub struct EventSender<E> {
     sender: Sender<E>,
+    timer_sender: Sender<(Instant, E)>,
     priority_sender: Sender<E>,
-    timer_registry: HashMap<usize, JoinHandle<()>>,
-    timers_running: Arc<AtomicBool>,
-    last_timer_id: usize,
 }
 
 impl<E> EventSender<E>
@@ -96,14 +127,13 @@ where E: Send + 'static
     const EVENT_SENDING_ERROR: &'static str =
         "The associated EventQueue must be alive for sending an event";
 
-    fn new(sender: Sender<E>, priority_sender: Sender<E>) -> EventSender<E> {
-        EventSender {
-            sender,
-            priority_sender,
-            timer_registry: HashMap::new(),
-            timers_running: Arc::new(AtomicBool::new(true)),
-            last_timer_id: 0,
-        }
+    fn new(
+        sender: Sender<E>,
+        timer_sender: Sender<(Instant, E)>,
+        priority_sender: Sender<E>,
+    ) -> EventSender<E>
+    {
+        EventSender { sender, timer_sender, priority_sender }
     }
 
     /// Send instantly an event to the event queue.
@@ -119,37 +149,10 @@ where E: Send + 'static
 
     /// Send a timed event to the [EventQueue].
     /// The event only will be sent after the specific duration, never before.
-    /// If the [EventSender] is dropped, the event will not be sent.
+    /// If the [EventSender] is dropped, the event will be generated as well.
     pub fn send_with_timer(&mut self, event: E, duration: Duration) {
-        let sender = self.sender.clone();
-        let timer_id = self.last_timer_id;
-        let running = self.timers_running.clone();
-        let mut time_acc = Duration::from_secs(0);
-        let duration_step = Duration::from_millis(TIMER_SAMPLING_CHECK);
-        let timer_handle = thread::Builder::new()
-            .name("message-io: timer".into())
-            .spawn(move || {
-                while time_acc < duration {
-                    thread::sleep(duration_step);
-                    time_acc += duration_step;
-                    if !running.load(Ordering::Relaxed) {
-                        return
-                    }
-                }
-                sender.send(event).expect(Self::EVENT_SENDING_ERROR);
-            })
-            .unwrap();
-        self.timer_registry.insert(timer_id, timer_handle);
-        self.last_timer_id += 1;
-    }
-}
-
-impl<E> Drop for EventSender<E> {
-    fn drop(&mut self) {
-        self.timers_running.store(false, Ordering::Relaxed);
-        for (_, timer) in self.timer_registry.drain() {
-            timer.join().unwrap();
-        }
+        let when = Instant::now() + duration;
+        self.timer_sender.send((when, event)).expect(Self::EVENT_SENDING_ERROR);
     }
 }
 
@@ -158,9 +161,7 @@ impl<E> Clone for EventSender<E> {
         Self {
             sender: self.sender.clone(),
             priority_sender: self.priority_sender.clone(),
-            timer_registry: HashMap::new(),
-            timers_running: Arc::new(AtomicBool::new(true)),
-            last_timer_id: 0,
+            timer_sender: self.timer_sender.clone(),
         }
     }
 }
@@ -175,8 +176,8 @@ mod tests {
 
     lazy_static::lazy_static! {
         static ref ZERO_MS: Duration = Duration::from_millis(0);
-        static ref TIMER_TIME: Duration = Duration::from_millis(TIMER_SAMPLING_CHECK);
-        static ref TIMEOUT: Duration = Duration::from_millis(TIMER_SAMPLING_CHECK + DELAY);
+        static ref TIMER_TIME: Duration = Duration::from_millis(100);
+        static ref TIMEOUT: Duration = *TIMER_TIME * 2  + Duration::from_millis(DELAY);
     }
 
     #[test]
@@ -209,20 +210,33 @@ mod tests {
     #[test]
     fn timer_events_order() {
         let mut queue = EventQueue::new();
-        queue.sender().send_with_timer("timed", Duration::from_millis(TIMER_SAMPLING_CHECK));
+        queue.sender().send_with_timer("timed_last", *TIMER_TIME * 2);
+        queue.sender().send_with_timer("timed_short", *TIMER_TIME);
+
+        std::thread::sleep(*TIMEOUT);
+        // The timed event has been received at this point
+
+        assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "timed_short");
+        assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "timed_last");
+    }
+
+    #[test]
+    fn default_and_timer_events_order() {
+        let mut queue = EventQueue::new();
+        queue.sender().send_with_timer("timed", *TIMER_TIME);
         queue.sender().send("standard_first");
         queue.sender().send("standard_second");
 
         std::thread::sleep(*TIMEOUT);
         // The timed event has been received at this point
 
+        assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "timed");
         assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "standard_first");
         assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "standard_second");
-        assert_eq!(queue.receive_timeout(*ZERO_MS).unwrap(), "timed");
     }
 
     #[test]
-    fn priority_and_time_events_order() {
+    fn priority_and_timer_events_order() {
         let mut queue = EventQueue::new();
         queue.sender().send_with_timer("timed", *TIMER_TIME);
         queue.sender().send_with_priority("priority");


### PR DESCRIPTION
- Fixed a leak memory produced in each timer sending
- The internals of timers uses now the `at` method from `crossbeam-channel 0.5`