### PR TITLE
Switch crossbeam_channel(deprecated) to crossbeam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +178,16 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -286,7 +310,7 @@ version = "0.5.1"
 dependencies = [
  "bincode",
  "criterion",
- "crossbeam-channel",
+ "crossbeam",
  "lazy_static",
  "log",
  "mio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 mio = { version = "0.7", features = ["os-poll", "tcp", "udp"] }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.1"
-crossbeam-channel = "0.5"
+crossbeam = "0.8"
 log = "0.4"
 net2 = "0.2.34"
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-use crossbeam_channel::{self, Sender, Receiver, select};
+use crossbeam::channel::{self, Sender, Receiver, select};
 
 use std::time::{Instant, Duration};
 use std::collections::{BTreeMap};
@@ -16,9 +16,9 @@ where E: Send + 'static
 {
     /// Creates a new event queue for generic incoming events.
     pub fn new() -> EventQueue<E> {
-        let (sender, receiver) = crossbeam_channel::unbounded();
-        let (timer_sender, timer_receiver) = crossbeam_channel::unbounded();
-        let (priority_sender, priority_receiver) = crossbeam_channel::unbounded();
+        let (sender, receiver) = channel::unbounded();
+        let (timer_sender, timer_receiver) = channel::unbounded();
+        let (priority_sender, priority_receiver) = channel::unbounded();
         EventQueue {
             event_sender: EventSender::new(sender, timer_sender, priority_sender),
             receiver,
@@ -65,7 +65,7 @@ where E: Send + 'static
                 select! {
                     recv(self.receiver) -> event => event.unwrap(),
                     recv(self.priority_receiver) -> event => event.unwrap(),
-                    recv(crossbeam_channel::at(next_instant)) -> _ => {
+                    recv(channel::at(next_instant)) -> _ => {
                         self.timers.remove(&next_instant).unwrap()
                     }
                 }
@@ -97,7 +97,7 @@ where E: Send + 'static
                 select! {
                     recv(self.receiver) -> event => Some(event.unwrap()),
                     recv(self.priority_receiver) -> event => Some(event.unwrap()),
-                    recv(crossbeam_channel::at(next_instant)) -> _ => {
+                    recv(channel::at(next_instant)) -> _ => {
                         self.timers.remove(&next_instant)
                     }
                     default(timeout) => None


### PR DESCRIPTION
Hello @lemunozm ~
As discussed in #20 , I've bump-up 'crossbeam_channel' to `crossbeam`.

Test has been passed, but please let me know if you think it needs more test cases.
