### PR TITLE
Fixed ResourceId for 32bits arch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,18 +14,20 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.rust }} on ${{ matrix.os }}
+    name: ${{ matrix.rust }} on ${{ matrix.os }}-${{matrix.platform}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
+        platform: [x32, x64]
         rust: [stable, nightly]
-        # Allow failures on nightly, it's just informative
         include:
           - rust: stable
             can-fail: false
           - rust: nightly
             can-fail: true
+          - os: ubuntu-latest
+            rust: 'stable'
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v1
@@ -58,7 +60,6 @@ jobs:
     - name: Check benchmarks (only compilation)
       run: cargo bench --no-run
       continue-on-error: ${{ matrix.can-fail }}
-
     - name: Test Packaging
       if: matrix.rust == 'stable'
       run: cargo package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Release 0.9.4
+- Fixed ResourceId to works with 32-bits.
+
 ## Release 0.9.3
 - Removed `EventQueue` drop restriction of having already droped the associated senders.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "message-io"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message-io"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -29,12 +29,12 @@ impl Default for AdapterLauncher {
     fn default() -> AdapterLauncher {
         Self {
             poll: Poll::default(),
-            controllers: (0..ResourceId::ADAPTER_ID_MAX)
+            controllers: (0..ResourceId::MAX_ADAPTERS)
                 .map(|_| {
                     Box::new(UnimplementedActionController) as Box<dyn ActionController + Send>
                 })
                 .collect::<Vec<_>>(),
-            processors: (0..ResourceId::ADAPTER_ID_MAX)
+            processors: (0..ResourceId::MAX_ADAPTERS)
                 .map(|_| Box::new(UnimplementedEventProcessor) as Box<dyn EventProcessor + Send>)
                 .collect(),
         }


### PR DESCRIPTION
From: https://github.com/lemunozm/message-io/issues/41

It was not as simple as modifying the `usize` to u64 because `mio` uses an `usize` internally too and the value is clamped by the 32-bits OS poll.

The fix encodes the adapter id and resource type information into the less significant bits instead of the most significant bits to be sure that whatever word size is used in the OS, these values are always encoded into the `ResourceId`.