### PR TITLE
Add try_recv() for non-blocking event queue reads

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -110,20 +110,22 @@ where E: Send + 'static
         }
     }
 
-    /// A non-blocking receive which returns instantly.
+    /// Attempts to receive an event without blocking.
     /// Returns Some(E) if an event was received by this queue, otherwise returns None.
-    pub fn try_recv(&mut self) -> Option<E> {
+    pub fn try_receive(&mut self) -> Option<E> {
         self.enque_timers();
 
         if let Ok(priority_event) = self.priority_receiver.try_recv() {
-            return Some(priority_event);
-        } else if let Some(next_instant) = self.timers.iter().next() {
-            let instant = *next_instant.0;
-            if instant <= Instant::now() {
-                return self.timers.remove(&instant);
+            return Some(priority_event)
+        }
+        else if let Some(next_instant) = self.timers.iter().next() {
+            if *next_instant.0 <= Instant::now() {
+                let instant = *next_instant.0;
+                return self.timers.remove(&instant)
             }
-        } else if let Ok(event) = self.receiver.try_recv() {
-            return Some(event);
+        }
+        else if let Ok(event) = self.receiver.try_recv() {
+            return Some(event)
         }
 
         None
@@ -282,44 +284,44 @@ mod tests {
     }
 
     #[test]
-    fn standard_events_order_try_recv() {
+    fn standard_events_order_try_receive() {
         let mut queue = EventQueue::new();
         queue.sender().send("first");
         queue.sender().send("second");
-        assert_eq!(queue.try_recv().unwrap(), "first");
-        assert_eq!(queue.try_recv().unwrap(), "second");
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive().unwrap(), "first");
+        assert_eq!(queue.try_receive().unwrap(), "second");
+        assert_eq!(queue.try_receive(), None);
     }
 
     #[test]
-    fn priority_events_order_try_recv() {
+    fn priority_events_order_try_receive() {
         let mut queue = EventQueue::new();
         queue.sender().send("standard");
         queue.sender().send_with_priority("priority_first");
         queue.sender().send_with_priority("priority_second");
-        assert_eq!(queue.try_recv().unwrap(), "priority_first");
-        assert_eq!(queue.try_recv().unwrap(), "priority_second");
-        assert_eq!(queue.try_recv().unwrap(), "standard");
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive().unwrap(), "priority_first");
+        assert_eq!(queue.try_receive().unwrap(), "priority_second");
+        assert_eq!(queue.try_receive().unwrap(), "standard");
+        assert_eq!(queue.try_receive(), None);
     }
 
     #[test]
-    fn timer_events_order_try_recv() {
+    fn timer_events_order_try_receive() {
         let mut queue = EventQueue::new();
         queue.sender().send_with_timer("timed_last", *TIMER_TIME * 2);
         queue.sender().send_with_timer("timed_short", *TIMER_TIME);
 
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive(), None);
         std::thread::sleep(*TIMER_TIME);
         // The timed event has been received at this point
-        assert_eq!(queue.try_recv().unwrap(), "timed_short");
+        assert_eq!(queue.try_receive().unwrap(), "timed_short");
         std::thread::sleep(*TIMER_TIME);
-        assert_eq!(queue.try_recv().unwrap(), "timed_last");
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive().unwrap(), "timed_last");
+        assert_eq!(queue.try_receive(), None);
     }
 
     #[test]
-    fn default_and_timer_events_order_try_recv() {
+    fn default_and_timer_events_order_try_receive() {
         let mut queue = EventQueue::new();
         queue.sender().send_with_timer("timed", *TIMER_TIME);
         queue.sender().send("standard_first");
@@ -328,14 +330,14 @@ mod tests {
         std::thread::sleep(*TIMEOUT);
         // The timed event has been received at this point
 
-        assert_eq!(queue.try_recv().unwrap(), "timed");
-        assert_eq!(queue.try_recv().unwrap(), "standard_first");
-        assert_eq!(queue.try_recv().unwrap(), "standard_second");
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive().unwrap(), "timed");
+        assert_eq!(queue.try_receive().unwrap(), "standard_first");
+        assert_eq!(queue.try_receive().unwrap(), "standard_second");
+        assert_eq!(queue.try_receive(), None);
     }
 
     #[test]
-    fn priority_and_timer_events_order_try_recv() {
+    fn priority_and_timer_events_order_try_receive() {
         let mut queue = EventQueue::new();
         queue.sender().send_with_timer("timed", *TIMER_TIME);
         queue.sender().send_with_priority("priority");
@@ -343,8 +345,8 @@ mod tests {
         std::thread::sleep(*TIMEOUT);
         // The timed event has been received at this point
 
-        assert_eq!(queue.try_recv().unwrap(), "priority");
-        assert_eq!(queue.try_recv().unwrap(), "timed");
-        assert_eq!(queue.try_recv(), None);
+        assert_eq!(queue.try_receive().unwrap(), "priority");
+        assert_eq!(queue.try_receive().unwrap(), "timed");
+        assert_eq!(queue.try_receive(), None);
     }
 }


### PR DESCRIPTION
Discussed in https://github.com/lemunozm/message-io/issues/46.

I tried to run rustfmt but ran into some issues with the .rustfmt.toml file. Probably a better idea to wait until that is fixed before merging this.

I also wrote some unit tests to cover some of the common use cases. Would appreciate some extra 👀 on it to make sure I've done it correctly. I'm sure there's a more elegant way of doing this but seems to serve as a solid foundation. Either way, feedback/comments appreciated!

**Discussion points:**
* Should this be named try_recv or try_receive?
* Does the comment look OK?
* I really wanted to avoid copying the instant but was running into multiple mutable borrow issues for self.timers