### PR TITLE
RemoteAddr extensions

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -7,6 +7,6 @@ use_field_init_shorthand = true
 use_try_shorthand = true
 where_single_line = true
 ignore = [
-    "examples/readme_echo_client.rs"
-    "examples/readme_echo_server.rs"
+    "examples/readme_echo_client.rs",
+    "examples/readme_echo_server.rs",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Release 0.11.0
+- Implemented `Serialize`/`Deserialize` for `Transport`.
+- Implemented `Serialize`/`Deserialize` for `RemoteAddr`.
+- Changed `Url` to `String` in `RemoteAddr`.
+- Increase the `ToRemoteAddr` support for many types.
+
 ## Release 0.10.2
 - Added `try_receive()` to `EventQueue` for non-blocking event read.
 - tests and benchmarks running with any number of features enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "message-io"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message-io"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ websocket = ["tungstenite", "mio/tcp"]
 
 [dependencies]
 mio = { version = "0.7", features = ["os-poll"] }
+serde = { version = "1.0", features = ["derive"] }
 crossbeam = "0.8"
 log = "0.4"
 net2 = "0.2.34"
@@ -33,7 +34,6 @@ url = "2.2.0"
 tungstenite = { version = "0.13.0", optional = true }
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.1"
 criterion = "0.3"
 fern = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ You could change the transport of your application in literally one line.
 ## Getting started
 Add to your `Cargo.toml` (all the transports included by default):
 ```
-message-io = "0.10"
+message-io = "0.11"
 ```
 If you **only** want to use a subset of the available transport battery,
 you can select them by their associated features `tcp`, `udp`, and `websocket`.
 For example, in order to include only *TCP* and *UDP*, add to your `Cargo.toml`:
 ```
-message-io = { version = "0.10", default-features = false, features = ["tcp", "udp"] }
+message-io = { version = "0.11", default-features = false, features = ["tcp", "udp"] }
 ```
 
 **Warning**: If you comming from **0.9.4 o less**, note that `Transport::Tcp` has been renamed

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -87,18 +87,25 @@ fn throughput_by(c: &mut Criterion, transport: Transport) {
 /// is out of scope of this tests. So, we could be adding an extra latency.
 /// How to avoid this time adition inside of Criterion framework?
 fn latency(c: &mut Criterion) {
-    #[cfg(feature = "udp")] latency_by(c, Transport::Udp);
-    #[cfg(feature = "tcp")] latency_by(c, Transport::Tcp);
-    #[cfg(feature = "tcp")] latency_by(c, Transport::FramedTcp);
-    #[cfg(feature = "websocket")] latency_by(c, Transport::Ws);
+    #[cfg(feature = "udp")]
+    latency_by(c, Transport::Udp);
+    #[cfg(feature = "tcp")]
+    latency_by(c, Transport::Tcp);
+    #[cfg(feature = "tcp")]
+    latency_by(c, Transport::FramedTcp);
+    #[cfg(feature = "websocket")]
+    latency_by(c, Transport::Ws);
 }
 
 fn throughput(c: &mut Criterion) {
-    #[cfg(feature = "udp")] throughput_by(c, Transport::Udp);
+    #[cfg(feature = "udp")]
+    throughput_by(c, Transport::Udp);
     //TODO: Fix this test: How to read inside of criterion iter()? an stream protocol?
     //#[cfg(feature = "tcp")] throughput_by(c, Transport::Tcp);
-    #[cfg(feature = "tcp")] throughput_by(c, Transport::FramedTcp);
-    #[cfg(feature = "websocket")] throughput_by(c, Transport::Ws);
+    #[cfg(feature = "tcp")]
+    throughput_by(c, Transport::FramedTcp);
+    #[cfg(feature = "websocket")]
+    throughput_by(c, Transport::Ws);
 }
 
 criterion_group!(benches, latency, throughput);

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,7 +1,11 @@
 pub mod template;
-#[cfg(feature = "tcp")] pub mod tcp;
-#[cfg(feature = "tcp")] pub mod framed_tcp;
-#[cfg(feature = "udp")] pub mod udp;
-#[cfg(feature = "websocket")] pub mod web_socket;
+#[cfg(feature = "tcp")]
+pub mod tcp;
+#[cfg(feature = "tcp")]
+pub mod framed_tcp;
+#[cfg(feature = "udp")]
+pub mod udp;
+#[cfg(feature = "websocket")]
+pub mod web_socket;
 // Add new adapters here
 // ...

--- a/src/adapters/web_socket.rs
+++ b/src/adapters/web_socket.rs
@@ -64,7 +64,8 @@ impl Remote for RemoteResource {
             RemoteAddr::SocketAddr(addr) => {
                 (addr, Url::parse(&format!("ws://{}/message-io-default", addr)).unwrap())
             }
-            RemoteAddr::Url(url) => {
+            RemoteAddr::Path(path) => {
+                let url = Url::parse(&path).expect("A valid URL");
                 let addr = url
                     .socket_addrs(|| match url.scheme() {
                         "ws" => Some(80),   // Plain

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -78,8 +78,7 @@ impl<R: Remote, L: Local> Driver<R, L> {
         _: impl Adapter<Remote = R, Local = L>,
         adapter_id: u8,
         poll: &mut Poll,
-    ) -> Driver<R, L>
-    {
+    ) -> Driver<R, L> {
         let remote_poll_register = poll.create_register(adapter_id, ResourceType::Remote);
         let local_poll_register = poll.create_register(adapter_id, ResourceType::Local);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -72,8 +72,7 @@ impl NetworkEngine {
     pub fn new(
         launcher: AdapterLauncher,
         event_callback: impl Fn(AdapterEvent<'_>) + Send + 'static,
-    ) -> Self
-    {
+    ) -> Self {
         let thread_running = Arc::new(AtomicBool::new(true));
         let running = thread_running.clone();
 
@@ -102,8 +101,7 @@ impl NetworkEngine {
         mut poll: Poll,
         mut processors: EventProcessors,
         event_callback: impl Fn(AdapterEvent<'_>) + Send + 'static,
-    ) -> JoinHandle<()>
-    {
+    ) -> JoinHandle<()> {
         thread::Builder::new()
             .name("message-io: event processor".into())
             .spawn(move || {
@@ -126,8 +124,7 @@ impl NetworkEngine {
         &mut self,
         adapter_id: u8,
         addr: RemoteAddr,
-    ) -> io::Result<(Endpoint, SocketAddr)>
-    {
+    ) -> io::Result<(Endpoint, SocketAddr)> {
         self.controllers[adapter_id as usize].connect(addr).map(|(endpoint, addr)| {
             log::trace!("Connected endpoint {} by {}", endpoint, adapter_id);
             (endpoint, addr)
@@ -139,8 +136,7 @@ impl NetworkEngine {
         &mut self,
         adapter_id: u8,
         addr: SocketAddr,
-    ) -> io::Result<(ResourceId, SocketAddr)>
-    {
+    ) -> io::Result<(ResourceId, SocketAddr)> {
         self.controllers[adapter_id as usize].listen(addr).map(|(resource_id, addr)| {
             log::trace!("New resource {} listening by {}", resource_id, adapter_id);
             (resource_id, addr)

--- a/src/events.rs
+++ b/src/events.rs
@@ -155,8 +155,7 @@ where E: Send + 'static
         sender: Sender<E>,
         timer_sender: Sender<(Instant, E)>,
         priority_sender: Sender<E>,
-    ) -> EventSender<E>
-    {
+    ) -> EventSender<E> {
         EventSender { sender, timer_sender, priority_sender }
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -190,8 +190,7 @@ impl Network {
         &mut self,
         transport: Transport,
         addr: impl ToRemoteAddr,
-    ) -> io::Result<(Endpoint, SocketAddr)>
-    {
+    ) -> io::Result<(Endpoint, SocketAddr)> {
         let addr = addr.to_remote_addr().unwrap();
         self.engine.connect(transport.id(), addr)
     }
@@ -206,8 +205,7 @@ impl Network {
         &mut self,
         transport: Transport,
         addr: impl ToSocketAddrs,
-    ) -> io::Result<(ResourceId, SocketAddr)>
-    {
+    ) -> io::Result<(ResourceId, SocketAddr)> {
         let addr = addr.to_socket_addrs().unwrap().next().unwrap();
         self.engine.listen(transport.id(), addr)
     }

--- a/src/remote_addr.rs
+++ b/src/remote_addr.rs
@@ -1,16 +1,16 @@
-use url::{Url};
+use serde::{Serialize, Deserialize};
 
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::io::{self};
 
 /// An struct that contains a remote address.
-/// It can be Either, an address similar to [`SocketAddr`] or an [`Url`] used for protocols
-/// that needs more than the `SocketAddr` to get connected (e.g. WebSocket)
+/// It can be Either, a [`SocketAddr`] as usual or a `String` used for protocols
+/// that needs more than a `SocketAddr` to get connected (e.g. WebSocket)
 /// It is usually used in [`crate::network::Network::connect()`] to specify the remote address.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum RemoteAddr {
     SocketAddr(SocketAddr),
-    Url(Url),
+    Path(String),
 }
 
 impl RemoteAddr {
@@ -19,12 +19,13 @@ impl RemoteAddr {
         matches!(self, RemoteAddr::SocketAddr(_))
     }
 
-    /// Check if the `RemoteAddr` is an [`Url`].
-    pub fn is_url(&self) -> bool {
-        matches!(self, RemoteAddr::Url(_))
+    /// Check if the `RemoteAddr` is a path.
+    pub fn is_path(&self) -> bool {
+        matches!(self, RemoteAddr::SocketAddr(_))
     }
 
-    /// Trait the `RemoteAddr` as a [`SocketAddr`].
+    /// Extract the [`SocketAddr`].
+    /// This function panics if the `RemoteAddr` do not represent a `SocketAddr`.
     pub fn socket_addr(&self) -> &SocketAddr {
         match self {
             RemoteAddr::SocketAddr(addr) => addr,
@@ -32,11 +33,12 @@ impl RemoteAddr {
         }
     }
 
-    /// Trait the `RemoteAddr` as an [`Url`].
-    pub fn url(&self) -> &Url {
+    /// Extract the path.
+    /// This function panics if the `RemoteAddr` do not represent a path.
+    pub fn path(&self) -> &str {
         match self {
-            RemoteAddr::Url(url) => url,
-            _ => panic!("The RemoteAddr must be an Url"),
+            RemoteAddr::Path(addr) => addr,
+            _ => panic!("The RemoteAddr must be a path"),
         }
     }
 }
@@ -46,11 +48,28 @@ impl ToSocketAddrs for RemoteAddr {
     fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
         match self {
             RemoteAddr::SocketAddr(addr) => addr.to_socket_addrs(),
-            RemoteAddr::Url(_) => Err(io::Error::new(io::ErrorKind::InvalidInput, "Malformed url")),
+            RemoteAddr::Path(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "The RemoteAddr is not a SocketAddr",
+            )),
         }
     }
 }
 
+impl std::fmt::Display for RemoteAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemoteAddr::SocketAddr(addr) => write!(f, "{}", addr),
+            RemoteAddr::Path(path) => write!(f, "{}", path),
+        }
+    }
+}
+
+/// Similar to [`ToSocketAddrs`] but for a `RemoteAddr`.
+/// Instead of `ToSocketAddrs` that only can accept valid 'ip:port' string format,
+/// `ToRemoteAddr` accept any string without panic.
+/// If the string has the 'ip:port' format, it will be interpreted as a [`SocketAddr`],
+/// if not, it will be interpreted as a string path.
 pub trait ToRemoteAddr {
     fn to_remote_addr(&self) -> io::Result<RemoteAddr>;
 }
@@ -59,10 +78,7 @@ impl ToRemoteAddr for &str {
     fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
         Ok(match self.parse() {
             Ok(addr) => RemoteAddr::SocketAddr(addr),
-            Err(_) => RemoteAddr::Url(
-                Url::parse(self)
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Malformed url"))?,
-            ),
+            Err(_) => RemoteAddr::Path(self.to_string()),
         })
     }
 }
@@ -85,18 +101,51 @@ impl ToRemoteAddr for SocketAddr {
     }
 }
 
+impl ToRemoteAddr for SocketAddrV4 {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(SocketAddr::V4(*self)))
+    }
+}
+
+impl ToRemoteAddr for SocketAddrV6 {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(SocketAddr::V6(*self)))
+    }
+}
+
 impl ToRemoteAddr for RemoteAddr {
     fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
         Ok(self.clone())
     }
 }
 
-impl std::fmt::Display for RemoteAddr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RemoteAddr::SocketAddr(addr) => write!(f, "{}", addr),
-            RemoteAddr::Url(url) => write!(f, "{}", url),
-        }
+impl ToRemoteAddr for (&str, u16) {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(self.to_socket_addrs().unwrap().next().unwrap()))
+    }
+}
+
+impl ToRemoteAddr for (String, u16) {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(self.to_socket_addrs().unwrap().next().unwrap()))
+    }
+}
+
+impl ToRemoteAddr for (IpAddr, u16) {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(self.to_socket_addrs().unwrap().next().unwrap()))
+    }
+}
+
+impl ToRemoteAddr for (Ipv4Addr, u16) {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(self.to_socket_addrs().unwrap().next().unwrap()))
+    }
+}
+
+impl ToRemoteAddr for (Ipv6Addr, u16) {
+    fn to_remote_addr(&self) -> io::Result<RemoteAddr> {
+        Ok(RemoteAddr::SocketAddr(self.to_socket_addrs().unwrap().next().unwrap()))
     }
 }
 
@@ -106,13 +155,15 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
-    fn str_to_url() {
-        assert!("ws://domain:1234/socket".to_remote_addr().unwrap().is_url());
+    fn str_to_path() {
+        let path = "ws://domain:1234/socket";
+        assert_eq!(path, path.to_remote_addr().unwrap().path());
     }
 
     #[test]
-    fn string_to_url() {
-        assert!(String::from("ws://domain:1234/socket").to_remote_addr().unwrap().is_url());
+    fn string_to_path() {
+        let path = String::from("ws://domain:1234/socket");
+        assert_eq!(&path, path.to_remote_addr().unwrap().path());
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,44 +1,50 @@
 use crate::engine::{AdapterLauncher};
 
-#[cfg(feature = "tcp")] use crate::adapters::tcp::{self, TcpAdapter};
-#[cfg(feature = "tcp")] use crate::adapters::framed_tcp::{self, FramedTcpAdapter};
-
-#[cfg(feature = "udp")] use crate::adapters::udp::{self, UdpAdapter};
-
-#[cfg(feature = "websocket")] use crate::adapters::web_socket::{self, WsAdapter};
+#[cfg(feature = "tcp")]
+use crate::adapters::tcp::{self, TcpAdapter};
+#[cfg(feature = "tcp")]
+use crate::adapters::framed_tcp::{self, FramedTcpAdapter};
+#[cfg(feature = "udp")]
+use crate::adapters::udp::{self, UdpAdapter};
+#[cfg(feature = "websocket")]
+use crate::adapters::web_socket::{self, WsAdapter};
 
 use strum::{EnumIter};
+use serde::{Serialize, Deserialize};
 
 /// Enum to identified the underlying transport used.
 /// It can be passed to [`crate::network::Network::connect()`] and
 /// [`crate::network::Network::listen()`] methods to specify the transport used.
-#[derive(EnumIter)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(EnumIter, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Transport {
     /// TCP protocol (available through the *tcp* feature).
     /// As stream protocol, receiving a message from TCP do not imply to read
     /// the entire message.
     /// If you want a packet based way to send over TCP, use `FramedTcp` instead.
-    #[cfg(feature = "tcp")] Tcp,
+    #[cfg(feature = "tcp")]
+    Tcp,
 
     /// Like TCP, but encoded with a slim frame layer to manage the data as a packet,
     /// instead of as a stream (available through the *tcp* feature).
     /// Most of the time you would want to use this instead of the raw `Tcp`.
-    #[cfg(feature = "tcp")] FramedTcp,
+    #[cfg(feature = "tcp")]
+    FramedTcp,
 
     /// UDP protocol (available through the *udp* feature).
     /// Take into account that UDP is not connection oriented and a packet can be lost
     /// or received disordered.
     /// If it is specified in the listener and the address is a Ipv4 in the range of multicast ips
     /// (from `224.0.0.0` to `239.255.255.255`), the listener will be configured in multicast mode.
-    #[cfg(feature = "udp")] Udp,
+    #[cfg(feature = "udp")]
+    Udp,
 
     /// WebSocket protocol (available through the *websocket* feature).
     /// If you use a [`crate::network::RemoteAddr::Url`] in the `connect()` method,
     /// you can specify `wss` of `ws` schemas to connect with or without security.
     /// If you use a [`crate::network::RemoteAddr::SocketAddr`] the socket will be a normal
     /// websocket with the following uri: `ws://{SocketAddr}/message-io-default`.
-    #[cfg(feature = "websocket")] Ws,
+    #[cfg(feature = "websocket")]
+    Ws,
 }
 
 impl Transport {
@@ -46,10 +52,14 @@ impl Transport {
     /// This method mounts the adapter to be used in the `Network`.
     pub fn mount_adapter(self, launcher: &mut AdapterLauncher) {
         match self {
-            #[cfg(feature = "tcp")] Self::Tcp => launcher.mount(self.id(), TcpAdapter),
-            #[cfg(feature = "tcp")] Self::FramedTcp => launcher.mount(self.id(), FramedTcpAdapter),
-            #[cfg(feature = "udp")] Self::Udp => launcher.mount(self.id(), UdpAdapter),
-            #[cfg(feature = "websocket")] Self::Ws => launcher.mount(self.id(), WsAdapter),
+            #[cfg(feature = "tcp")]
+            Self::Tcp => launcher.mount(self.id(), TcpAdapter),
+            #[cfg(feature = "tcp")]
+            Self::FramedTcp => launcher.mount(self.id(), FramedTcpAdapter),
+            #[cfg(feature = "udp")]
+            Self::Udp => launcher.mount(self.id(), UdpAdapter),
+            #[cfg(feature = "websocket")]
+            Self::Ws => launcher.mount(self.id(), WsAdapter),
         };
     }
 
@@ -58,10 +68,14 @@ impl Transport {
     /// the returned value correspond with the maximum bytes that can produce a read event.
     pub const fn max_message_size(self) -> usize {
         match self {
-            #[cfg(feature = "tcp")] Self::Tcp => tcp::INPUT_BUFFER_SIZE,
-            #[cfg(feature = "tcp")] Self::FramedTcp => framed_tcp::MAX_TCP_PAYLOAD_LEN,
-            #[cfg(feature = "udp")] Self::Udp => udp::MAX_UDP_PAYLOAD_LEN,
-            #[cfg(feature = "websocket")] Self::Ws => web_socket::MAX_WS_PAYLOAD_LEN,
+            #[cfg(feature = "tcp")]
+            Self::Tcp => tcp::INPUT_BUFFER_SIZE,
+            #[cfg(feature = "tcp")]
+            Self::FramedTcp => framed_tcp::MAX_TCP_PAYLOAD_LEN,
+            #[cfg(feature = "udp")]
+            Self::Udp => udp::MAX_UDP_PAYLOAD_LEN,
+            #[cfg(feature = "websocket")]
+            Self::Ws => web_socket::MAX_WS_PAYLOAD_LEN,
         }
     }
 
@@ -69,10 +83,14 @@ impl Transport {
     /// If it is, `Connection` and `Disconnection` events will be generated.
     pub const fn is_connection_oriented(self) -> bool {
         match self {
-            #[cfg(feature = "tcp")] Transport::Tcp => true,
-            #[cfg(feature = "tcp")] Transport::FramedTcp => true,
-            #[cfg(feature = "udp")] Transport::Udp => false,
-            #[cfg(feature = "websocket")] Transport::Ws => true,
+            #[cfg(feature = "tcp")]
+            Transport::Tcp => true,
+            #[cfg(feature = "tcp")]
+            Transport::FramedTcp => true,
+            #[cfg(feature = "udp")]
+            Transport::Udp => false,
+            #[cfg(feature = "websocket")]
+            Transport::Ws => true,
         }
     }
 
@@ -83,10 +101,14 @@ impl Transport {
     /// It is in change of the user to determinate how to read the data.
     pub const fn is_packet_based(self) -> bool {
         match self {
-            #[cfg(feature = "tcp")] Transport::Tcp => false,
-            #[cfg(feature = "tcp")] Transport::FramedTcp => true,
-            #[cfg(feature = "udp")] Transport::Udp => true,
-            #[cfg(feature = "websocket")] Transport::Ws => true,
+            #[cfg(feature = "tcp")]
+            Transport::Tcp => false,
+            #[cfg(feature = "tcp")]
+            Transport::FramedTcp => true,
+            #[cfg(feature = "udp")]
+            Transport::Udp => true,
+            #[cfg(feature = "websocket")]
+            Transport::Ws => true,
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -54,8 +54,7 @@ mod util {
 fn echo_server_handle(
     transport: Transport,
     expected_clients: usize,
-) -> (JoinHandle<()>, SocketAddr)
-{
+) -> (JoinHandle<()>, SocketAddr) {
     let (tx, rx) = crossbeam::channel::bounded(1);
     let handle = thread::Builder::new()
         .name("test-server".into())
@@ -123,8 +122,7 @@ fn echo_client_manager_handle(
     transport: Transport,
     server_addr: SocketAddr,
     clients_number: usize,
-) -> JoinHandle<()>
-{
+) -> JoinHandle<()> {
     thread::Builder::new()
         .name("test-client".into())
         .spawn(move || {
@@ -163,8 +161,7 @@ fn echo_client_manager_handle(
 fn burst_receiver_handle(
     transport: Transport,
     expected_count: usize,
-) -> (JoinHandle<()>, SocketAddr)
-{
+) -> (JoinHandle<()>, SocketAddr) {
     let (tx, rx) = crossbeam::channel::bounded(1);
     let handle = thread::Builder::new()
         .name("test-client".into())
@@ -201,8 +198,7 @@ fn burst_sender_handle(
     transport: Transport,
     receiver_addr: SocketAddr,
     expected_count: usize,
-) -> JoinHandle<()>
-{
+) -> JoinHandle<()> {
     thread::Builder::new()
         .name("test-client".into())
         .spawn(move || {


### PR DESCRIPTION
- Implemented `Serialize`/`Deserialize` for `Transport`.
- Implemented `Serialize`/`Deserialize` for `RemoteAddr`.
- Changed `Url` to `String` in `RemoteAddr`.
- Increase the `ToRemoteAddr` support for many types.