### PR TITLE
Fixed sending UDP and WS sending methods for packet limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Release 0.12.1
+- *WebSocket* now can returns when send correctly a `SendStatus::MaxPacketSizeExceeded` instead of `ResourceNotFound` if the packet size is exceeded.
+- *UDP* has increases the packet size when send.
+  Now more bytes per packet can be sent if the OS let it.
+- Exported some adapter constants dependent.
+- `Transport::max_message_size()` now represents the teorical maximum size (see its related docs).
+
 ## Release 0.12.0
 - Node concept: `NodeHandler` and `NodeListener`.
 - Non-mutable and shared network operations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "message-io"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message-io"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -1,7 +1,7 @@
 use message_io::network::{self, Transport, NetworkController, NetworkProcessor, Endpoint};
 use message_io::util::thread::{NamespacedThread};
 
-use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use std::time::{Duration};
 use std::sync::{
@@ -49,44 +49,6 @@ fn latency_by(c: &mut Criterion, transport: Transport) {
     });
 }
 
-fn throughput_by(c: &mut Criterion, transport: Transport) {
-    let sizes = [1, 2, 4, 8, 16, 32, 64, 128]
-        .iter()
-        .map(|i| i * 1024)
-        .filter(|&size| size < transport.max_message_size());
-
-    for block_size in sizes {
-        let mut group = c.benchmark_group(format!("throughput by {}", transport));
-        group.throughput(Throughput::Bytes(block_size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(block_size), &block_size, |b, &size| {
-            let (controller, mut processor, endpoint) = init_connection(transport);
-
-            let thread_running = Arc::new(AtomicBool::new(true));
-            let running = thread_running.clone();
-            let (tx, rx) = std::sync::mpsc::channel();
-            let mut thread = NamespacedThread::spawn("perf-sender", move || {
-                let message = (0..size).map(|_| 0xFF).collect::<Vec<u8>>();
-                tx.send(()).unwrap(); // receiving thread ready
-                while running.load(Ordering::Relaxed) {
-                    controller.send(endpoint, &message);
-                }
-            });
-            rx.recv().unwrap();
-
-            b.iter(|| {
-                // FIX IT:
-                // Because the sender do not stop sends, the receiver has always data.
-                // This means that only one poll event is generated for all messages, and
-                // process_poll_event will call the callback continuously without ends.
-                processor.process_poll_event(Some(*TIMEOUT), |_| ());
-            });
-
-            thread_running.store(true, Ordering::Relaxed);
-            thread.join();
-        });
-    }
-}
-
 fn latency(c: &mut Criterion) {
     #[cfg(feature = "udp")]
     latency_by(c, Transport::Udp);
@@ -98,18 +60,5 @@ fn latency(c: &mut Criterion) {
     latency_by(c, Transport::Ws);
 }
 
-#[allow(dead_code)] //TODO: remove when the throughput test works fine
-fn throughput(c: &mut Criterion) {
-    #[cfg(feature = "udp")]
-    throughput_by(c, Transport::Udp);
-    // TODO: Fix this test: How to read inside of criterion iter() an stream protocol?
-    // #[cfg(feature = "tcp")]
-    // throughput_by(c, Transport::Tcp);
-    #[cfg(feature = "tcp")]
-    throughput_by(c, Transport::FramedTcp);
-    #[cfg(feature = "websocket")]
-    throughput_by(c, Transport::Ws);
-}
-
-criterion_group!(benches, latency /*throughput*/,);
+criterion_group!(benches, latency);
 criterion_main!(benches);

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -6,6 +6,6 @@ pub mod framed_tcp;
 #[cfg(feature = "udp")]
 pub mod udp;
 #[cfg(feature = "websocket")]
-pub mod web_socket;
+pub mod ws;
 // Add new adapters here
 // ...

--- a/src/adapters/framed_tcp.rs
+++ b/src/adapters/framed_tcp.rs
@@ -14,20 +14,15 @@ use std::ops::{Deref};
 use std::cell::{RefCell};
 use std::mem::{MaybeUninit};
 
-const INPUT_BUFFER_SIZE: usize = 65535; // 2^16 - 1
+const INPUT_BUFFER_SIZE: usize = u16::MAX as usize; // 2^16 - 1
 
-/// The max packet value for tcp.
-/// Although this size is very high, it is preferred send data in smaller chunks with a rate
-/// to not saturate the receiver thread in the endpoint.
-pub const MAX_TCP_PAYLOAD_LEN: usize = usize::MAX;
-
-pub struct FramedTcpAdapter;
+pub(crate) struct FramedTcpAdapter;
 impl Adapter for FramedTcpAdapter {
     type Remote = RemoteResource;
     type Local = LocalResource;
 }
 
-pub struct RemoteResource {
+pub(crate) struct RemoteResource {
     stream: TcpStream,
     decoder: RefCell<Decoder>,
 }
@@ -119,7 +114,7 @@ impl Remote for RemoteResource {
     }
 }
 
-pub struct LocalResource {
+pub(crate) struct LocalResource {
     listener: TcpListener,
 }
 

--- a/src/adapters/tcp.rs
+++ b/src/adapters/tcp.rs
@@ -12,15 +12,18 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::ops::{Deref};
 use std::mem::{MaybeUninit};
 
-pub const INPUT_BUFFER_SIZE: usize = 65535; // 2^16 - 1
+/// Size of the internal reading buffer.
+/// It implies that at most the generated [`crate::network::NetEvent::Message`]
+/// will contains a chunk of data of this value.
+pub const INPUT_BUFFER_SIZE: usize = u16::MAX as usize; // 2^16 - 1
 
-pub struct TcpAdapter;
+pub(crate) struct TcpAdapter;
 impl Adapter for TcpAdapter {
     type Remote = RemoteResource;
     type Local = LocalResource;
 }
 
-pub struct RemoteResource {
+pub(crate) struct RemoteResource {
     stream: TcpStream,
 }
 
@@ -97,7 +100,7 @@ impl Remote for RemoteResource {
     }
 }
 
-pub struct LocalResource {
+pub(crate) struct LocalResource {
     listener: TcpListener,
 }
 

--- a/src/adapters/template.rs
+++ b/src/adapters/template.rs
@@ -11,13 +11,13 @@ use mio::event::{Source};
 use std::net::{SocketAddr};
 use std::io::{self};
 
-pub struct MyAdapter;
+pub(crate) struct MyAdapter;
 impl Adapter for MyAdapter {
     type Remote = RemoteResource;
     type Local = LocalResource;
 }
 
-pub struct RemoteResource;
+pub(crate) struct RemoteResource;
 impl Resource for RemoteResource {
     fn source(&mut self) -> &mut dyn Source {
         todo!();
@@ -38,7 +38,7 @@ impl Remote for RemoteResource {
     }
 }
 
-pub struct LocalResource;
+pub(crate) struct LocalResource;
 impl Resource for LocalResource {
     fn source(&mut self) -> &mut dyn Source {
         todo!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@
 // Tells rustdoc where is the README to compile and test the rust code found there
 doc_comment::doctest!("../README.md");
 
-mod adapters;
+/// Adapter related information.
+/// If some adapter has special values or configuration, it is specified here.
+pub mod adapters;
 
 /// Main API. Create connections, send and receive message, signals,...
 pub mod node;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,7 @@
 use message_io::network::{NetEvent, Transport, SendStatus};
 use message_io::node::{self, NodeEvent};
 use message_io::util::thread::{NamespacedThread};
+use message_io::adapters::udp::{self};
 
 use test_case::test_case;
 
@@ -251,12 +252,12 @@ fn burst(transport: Transport, messages_count: usize) {
 
 #[cfg_attr(feature = "tcp", test_case(Transport::Tcp, BIG_MESSAGE_SIZE))]
 #[cfg_attr(feature = "tcp", test_case(Transport::FramedTcp, BIG_MESSAGE_SIZE))]
-#[cfg_attr(feature = "udp", test_case(Transport::Udp, Transport::Udp.max_message_size()))]
+#[cfg_attr(feature = "udp", test_case(Transport::Udp, udp::MAX_COMPATIBLE_PAYLOAD_LEN))]
 #[cfg_attr(feature = "websocket", test_case(Transport::Ws, BIG_MESSAGE_SIZE))]
 fn message_size(transport: Transport, message_size: usize) {
     //util::init_logger(LogThread::Enabled); // Enable it for better debugging
 
-    assert!(!transport.is_packet_based() || message_size <= transport.max_message_size());
+    assert!(message_size <= transport.max_message_size());
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
     let sent_message: Vec<u8> = (0..message_size).map(|_| rng.gen()).collect();


### PR DESCRIPTION
- *WebSocket* now can returns when send correctly a `SendStatus::MaxPacketSizeExceeded` instead of `ResourceNotFound` if the packet size is exceeded.
- *UDP* has increases the packet size when send.
  Now more bytes per packet can be sent if the OS let it.
- Exported some adapter constants dependent.
- `Transport::max_message_size()` now represents the teorical maximum size (see its related docs).