### PR TITLE
Reduced dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Release 0.13.2
+- Faster compilation. reduced some dependencies.
+
 ## Release 0.13.1
 - Added `NodeListener::enqueue()`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "message-io"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,20 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,16 +221,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -511,7 +487,7 @@ dependencies = [
  "bincode",
  "chrono",
  "criterion",
- "crossbeam",
+ "crossbeam-channel",
  "doc-comment",
  "fern",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,17 @@ all-features = true
 default = ["tcp", "udp", "websocket"] # All features by default
 tcp = ["mio/tcp"]
 udp = ["mio/udp"]
-websocket = ["tungstenite", "mio/tcp"]
+websocket = ["tungstenite", "url", "mio/tcp"]
 
 [dependencies]
 mio = { version = "0.7", features = ["os-poll"] }
 serde = { version = "1.0", features = ["derive"] }
-crossbeam = "0.8"
+crossbeam-channel = "0.5"
 log = "0.4"
 net2 = "0.2.34"
 strum = { version = "0.20", features = ["derive"] }
-url = "2.2.0"
-tungstenite = { version = "0.13.0", optional = true }
+tungstenite = { version = "0.13", optional = true }
+url = { version = "2.2", optional = true }
 integer-encoding = "3.0.2"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message-io"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["lemunozm <lemunozm@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-use crossbeam::channel::{self, Sender, Receiver, select};
+use crossbeam_channel::{self, Sender, Receiver, select};
 
 use std::time::{Instant, Duration};
 use std::collections::{BTreeMap};
@@ -38,9 +38,9 @@ where E: Send + 'static
 {
     /// Creates a new event queue for generic incoming events.
     fn default() -> Self {
-        let (sender, receiver) = channel::unbounded();
-        let (timer_sender, timer_receiver) = channel::unbounded();
-        let (priority_sender, priority_receiver) = channel::unbounded();
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (timer_sender, timer_receiver) = crossbeam_channel::unbounded();
+        let (priority_sender, priority_receiver) = crossbeam_channel::unbounded();
         EventReceiver {
             event_sender: EventSender::new(sender, timer_sender, priority_sender),
             receiver,
@@ -91,7 +91,7 @@ where E: Send + 'static
                 select! {
                     recv(self.receiver) -> event => event.unwrap(),
                     recv(self.priority_receiver) -> event => event.unwrap(),
-                    recv(channel::at(next_instant)) -> _ => {
+                    recv(crossbeam_channel::at(next_instant)) -> _ => {
                         self.timers.remove(&next_instant).unwrap()
                     }
                 }
@@ -123,7 +123,7 @@ where E: Send + 'static
                 select! {
                     recv(self.receiver) -> event => Some(event.unwrap()),
                     recv(self.priority_receiver) -> event => Some(event.unwrap()),
-                    recv(channel::at(next_instant)) -> _ => {
+                    recv(crossbeam_channel::at(next_instant)) -> _ => {
                         self.timers.remove(&next_instant)
                     }
                     default(timeout) => None

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,7 +67,7 @@ fn start_echo_server(
     transport: Transport,
     expected_clients: usize,
 ) -> (NamespacedThread<()>, SocketAddr) {
-    let (tx, rx) = crossbeam::channel::bounded(1);
+    let (tx, rx) = crossbeam_channel::bounded(1);
     let thread = NamespacedThread::spawn("test-server", move || {
         let mut messages_received = 0;
         let mut disconnections = 0;
@@ -169,7 +169,7 @@ fn start_burst_receiver(
     transport: Transport,
     expected_count: usize,
 ) -> (NamespacedThread<()>, SocketAddr) {
-    let (tx, rx) = crossbeam::channel::bounded(1);
+    let (tx, rx) = crossbeam_channel::bounded(1);
     let thread = NamespacedThread::spawn("test-receiver", move || {
         let (node, listener) = node::split();
         node.signals().send_with_timer((), *TIMEOUT);


### PR DESCRIPTION
Reduced some compilation dependencies (around 10-20 less external dependencies depending on the features):
- `url`: Now, only compiled when the `websocket` feature is enabled. 
- Changed `crossbeam` to `crossbeam_channel`: The `crossbeam` was adding the entire suite of crossbeam libraries when only the channel was used. There is a PR https://github.com/lemunozm/message-io/pull/21 doing the opposite, but it seems that targeting the channel part of the `crossbeam` is correct.