### PR TITLE
Reduced NodeHandler clone cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 0.13.2
 - Faster compilation. reduced some dependencies.
+- Faster `NodeHandler` clone and less memory usage in each instance.
 
 ## Release 0.13.1
 - Added `NodeListener::enqueue()`.


### PR DESCRIPTION
Although the `NodeHandler` was already clonable. It underlying contained three Arcs. Because the NodeHandler is an entity that in practice can be copied hundred or thousands of times this Arcs quantity has been reduced to one to save more memory and be faster in the clones