### PR TITLE
Enabled public endpoint construction. Added example with listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Release 0.13.2
+- Added `Endpoint::from_listener()` that allows to send datagrams from listeners in non connection-oriented protocols (see the API docs).
 - Removed `'static` restriction in the `NodeListener::for_each()` callback.
 Now, you can pass references to the callback.
 - Faster compilation. Reduced some dependencies.

--- a/src/network/endpoint.rs
+++ b/src/network/endpoint.rs
@@ -11,8 +11,48 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Creates a new Endpoint.
-    pub(crate) fn new(resource_id: ResourceId, addr: SocketAddr) -> Self {
+    /// Creates a new Endpoint to use in non connection oriented protocols.
+    ///
+    /// For non connection-oriented protocols, as *UDP*, the endpoint can be created manually
+    /// from a listener resource to send messages to different address without creating a connection.
+    ///
+    /// For connection oriented protocol, to create manually and endpoint is not allowed.
+    ///
+    /// # Example
+    /// ```rust
+    /// use message_io::node::{self, NodeEvent};
+    /// use message_io::network::{Transport, Endpoint, NetEvent};
+    ///
+    /// let (handler, listener) = node::split::<()>();
+    /// handler.signals().send_with_timer((), std::time::Duration::from_secs(1)); //timeout
+    ///
+    /// let listen_addr = "127.0.0.1:0";
+    /// let (receiver_id_1, addr_1) = handler.network().listen(Transport::Udp, listen_addr).unwrap();
+    /// let (receiver_id_2, addr_2) = handler.network().listen(Transport::Udp, listen_addr).unwrap();
+    /// let (sender_id, _) = handler.network().listen(Transport::Udp, listen_addr).unwrap();
+    ///
+    /// //addr_1 and addr_2 contains the address with the listening port.
+    /// handler.network().send(Endpoint::new(sender_id, addr_1), &[23]);
+    /// handler.network().send(Endpoint::new(sender_id, addr_2), &[42]);
+    ///
+    /// let (mut msg_1, mut msg_2) = (0, 0);
+    /// listener.for_each(move |event| {
+    /// match event {
+    ///     NodeEvent::Signal(_) => {
+    ///         assert_eq!((msg_1, msg_2), (23, 42));
+    ///         handler.stop();
+    ///     }
+    ///     NodeEvent::Network(net_event) => match net_event {
+    ///         NetEvent::Message(endpoint, message) => match endpoint.resource_id() {
+    ///             id if id == receiver_id_1 => msg_1 = message[0],
+    ///             id if id == receiver_id_2 => msg_2 = message[0],
+    ///             _ => unreachable!(),
+    ///         }
+    ///         _ => unreachable!(),
+    ///     }}
+    /// });
+    /// ```
+    pub fn new(resource_id: ResourceId, addr: SocketAddr) -> Self {
         Self { resource_id, addr }
     }
 

--- a/src/network/endpoint.rs
+++ b/src/network/endpoint.rs
@@ -36,12 +36,8 @@ impl Endpoint {
     /// handler.network().send(Endpoint::new(sender_id, addr_2), &[42]);
     ///
     /// let (mut msg_1, mut msg_2) = (0, 0);
-    /// listener.for_each(move |event| {
-    /// match event {
-    ///     NodeEvent::Signal(_) => {
-    ///         assert_eq!((msg_1, msg_2), (23, 42));
-    ///         handler.stop();
-    ///     }
+    /// listener.for_each(|event| match event {
+    ///     NodeEvent::Signal(_) => handler.stop(),
     ///     NodeEvent::Network(net_event) => match net_event {
     ///         NetEvent::Message(endpoint, message) => match endpoint.resource_id() {
     ///             id if id == receiver_id_1 => msg_1 = message[0],
@@ -49,8 +45,10 @@ impl Endpoint {
     ///             _ => unreachable!(),
     ///         }
     ///         _ => unreachable!(),
-    ///     }}
+    ///     }
     /// });
+    ///
+    /// assert_eq!((msg_1, msg_2), (23, 42));
     /// ```
     pub fn new(resource_id: ResourceId, addr: SocketAddr) -> Self {
         Self { resource_id, addr }

--- a/src/network/transport.rs
+++ b/src/network/transport.rs
@@ -101,9 +101,10 @@ impl Transport {
         }
     }
 
-    /// Tell if the transport protocol is a packet based protocol.
+    /// Tell if the transport protocol is a packet-based protocol.
     /// It implies that any send call corresponds to a data message event.
-    /// The opossite of a packet based is a stream based transport (e.g Tcp).
+    /// It satisfies that the number of bytes sent are the same as received.
+    /// The opossite of a packet-based is a stream-based transport (e.g Tcp).
     /// In this case, reading a data message event do not imply reading the entire message sent.
     /// It is in change of the user to determinate how to read the data.
     pub const fn is_packet_based(self) -> bool {


### PR DESCRIPTION
- The user can create its own Endpoint with listeners from non-connection oriented transport protocols