### PR TITLE
Send updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Now it performs a non-blocking connection. Previous behaviour with `connect_sync
 - Adapter API modified to handle easily handshakes.
 - Fixed websocket issue that could offer an accepted connection that was yet not valid.
 - Added `NetworkController::is_ready()`
-- Added `SendStatus::ResourceNotAvailable`
 - Added `borrow()` method for `StoredNetEvent` to transform in into `NetEvent`.
 - Added `is_local()` and `is_remote()` helpers to `ResourceId`.
+- Modified `SendStatus::MaxPacketSizeExceeded`, now it not contains lengths info.
 
 ## Release 0.13.3
 - Fixed a bad internal assert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Now it performs a non-blocking connection. Previous behaviour with `connect_sync
 - Added `NetworkController::is_ready()`
 - Added `borrow()` method for `StoredNetEvent` to transform in into `NetEvent`.
 - Added `is_local()` and `is_remote()` helpers to `ResourceId`.
+- Added `SendStatus::ResourceNotAvailable`
 - Modified `SendStatus::MaxPacketSizeExceeded`, now it not contains lengths info.
 - Renamed `udp::MAX_COMPATIBLE_PAYLOAD_LEN` to `udp::MAX_LOCAL_PAYLOAD_LEN`, value updated
 with `udp::MAX_PAYLOAD_LEN`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Now it performs a non-blocking connection. Previous behaviour with `connect_sync
 - Added `borrow()` method for `StoredNetEvent` to transform in into `NetEvent`.
 - Added `is_local()` and `is_remote()` helpers to `ResourceId`.
 - Modified `SendStatus::MaxPacketSizeExceeded`, now it not contains lengths info.
+- Renamed `udp::MAX_COMPATIBLE_PAYLOAD_LEN` to `udp::MAX_LOCAL_PAYLOAD_LEN`, value updated
+with `udp::MAX_PAYLOAD_LEN`.
+- Removed `udp::MAX_PAYLOAD_LEN`.
+- Added `udp::MAX_NETWORK_PAYLOAD_LEN`.
 
 ## Release 0.13.3
 - Fixed a bad internal assert.

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -18,7 +18,7 @@ use std::sync::{
 use std::io::{Write, Read};
 
 lazy_static::lazy_static! {
-    static ref TIMEOUT: Duration = Duration::from_millis(100);
+    static ref TIMEOUT: Duration = Duration::from_millis(1);
 }
 
 fn init_connection(transport: Transport) -> (NetworkController, NetworkProcessor, Endpoint) {
@@ -36,7 +36,7 @@ fn init_connection(transport: Transport) -> (NetworkController, NetworkProcessor
     };
 
     let receiver_addr = controller.listen(transport, "127.0.0.1:0").unwrap().1;
-    let receiver = controller.connect(transport, receiver_addr).unwrap().0;
+    let receiver = controller.connect_sync(transport, receiver_addr).unwrap().0;
 
     running.store(false, Ordering::Relaxed);
     let processor = thread.join();

--- a/examples/throughput/main.rs
+++ b/examples/throughput/main.rs
@@ -17,13 +17,7 @@ use std::io::{self, Write, Read};
 
 const EXPECTED_BYTES: usize = 1024 * 1024 * 1024; // 1GB
 
-// Used the localhost MTU size (arround 65000 bytes in most OS) to get the better performance.
-// Note: MacOS uses a lower localhost MTU (arround 9000 bytes).
-// If you are running this test in MacOS, you probably see lower values that in other OS.
-// This does not means that MacOS running slower,
-// since real environments uses an MTU of arround 1500 bytes.
-const CHUNK: usize =
-    if cfg!(macos) { udp::MAX_COMPATIBLE_PAYLOAD_LEN } else { udp::MAX_PAYLOAD_LEN };
+const CHUNK: usize = udp::MAX_LOCAL_PAYLOAD_LEN;
 
 fn main() {
     println!("Sending 1GB in chunks of {} bytes:\n", CHUNK);

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -150,14 +150,7 @@ fn send_packet(data: &[u8], send_method: impl Fn(&[u8]) -> io::Result<usize>) ->
             }
             Err(ref err) if err.kind() == ErrorKind::WouldBlock => continue,
             Err(ref err) if err.kind() == ErrorKind::Other => {
-                let expected_assumption = if data.len() > MAX_PAYLOAD_LEN {
-                    MAX_PAYLOAD_LEN
-                }
-                else {
-                    // e.g. MacOS do not support the MAX UDP MTU.
-                    MAX_COMPATIBLE_PAYLOAD_LEN
-                };
-                break SendStatus::MaxPacketSizeExceeded(data.len(), expected_assumption)
+                break SendStatus::MaxPacketSizeExceeded
             }
             Err(err) => {
                 log::error!("UDP send error: {}", err);

--- a/src/adapters/ws.rs
+++ b/src/adapters/ws.rs
@@ -161,9 +161,7 @@ impl Remote for RemoteResource {
                         Err(Error::Io(ref err)) if err.kind() == ErrorKind::WouldBlock => {
                             result = web_socket.write_pending();
                         }
-                        Err(Error::Capacity(_)) => {
-                            break SendStatus::MaxPacketSizeExceeded(data.len(), MAX_PAYLOAD_LEN)
-                        }
+                        Err(Error::Capacity(_)) => break SendStatus::MaxPacketSizeExceeded,
                         Err(err) => {
                             log::error!("WS send error: {}", err);
                             break SendStatus::ResourceNotFound // should not happen

--- a/src/network.rs
+++ b/src/network.rs
@@ -353,6 +353,8 @@ mod tests {
         controller.remove(listener_id);
 
         let (endpoint, _) = controller.connect(transport, addr).unwrap();
+        assert_eq!(controller.send(endpoint, &[42]), SendStatus::ResourceNotAvailable);
+        assert!(!controller.is_ready(endpoint.resource_id()).unwrap());
 
         let mut was_disconnected = false;
         processor.process_poll_events_until_timeout(*LOCALHOST_CONN_TIMEOUT, |net_event| {
@@ -381,7 +383,7 @@ mod tests {
 
         let mut thread = NamespacedThread::spawn("test", move || {
             let err = controller.connect_sync(transport, addr).unwrap_err();
-            assert!(err.kind() == io::ErrorKind::ConnectionRefused);
+            assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
         });
 
         processor.process_poll_events_until_timeout(*LOCALHOST_CONN_TIMEOUT, |_| ());

--- a/src/network.rs
+++ b/src/network.rs
@@ -111,13 +111,14 @@ impl NetworkController {
 
     /// Creates a connection to the specified address.
     /// This function is similar to [`NetworkController::connect()`] but will block
-    /// to perform the connection, waiting until for the connection is ready.
+    /// until for the connection is ready.
     /// If the connection can not be established, a `ConnectionRefused` error will be returned.
     ///
     /// Note that the `Connect` event will be also generated.
     ///
-    /// Since this function blocks the current thread, it must not be used inside
-    /// the network callback.
+    /// Since this function blocks the current thread, it must NOT be used inside
+    /// the network callback because the internal event could not be processed.
+    ///
     /// In order to get the best scalability and performance, use the non-blocking
     /// [`NetworkController::connect()`] version.
     ///
@@ -150,11 +151,8 @@ impl NetworkController {
         loop {
             std::thread::sleep(Duration::from_millis(1));
             match self.is_ready(endpoint.resource_id()) {
-                Some(status) => {
-                    if status {
-                        return Ok((endpoint, addr))
-                    }
-                }
+                Some(true) => return Ok((endpoint, addr)),
+                Some(false) => continue,
                 None => {
                     return Err(io::Error::new(
                         io::ErrorKind::ConnectionRefused,

--- a/src/network/adapter.rs
+++ b/src/network/adapter.rs
@@ -71,6 +71,10 @@ pub enum SendStatus {
     /// This implies that a [`crate::network::NetEvent::Disconnected`] has happened or that
     /// the resource never existed.
     ResourceNotFound,
+
+    /// The resource can not perform the required send operation.
+    /// Usually this is due because it is performing the handshake.
+    ResourceNotAvailable,
 }
 
 /// Returned as a result of [`Remote::receive()`]

--- a/src/network/adapter.rs
+++ b/src/network/adapter.rs
@@ -63,20 +63,14 @@ pub enum SendStatus {
     /// It means that the correspond adapter has sent the message to the OS without errors.
     Sent,
 
-    /// This status is received in datagram-based protocols where there is a limit in the bytes
+    /// This status is received in packet-based protocols where there is a limit in the bytes
     /// that a packet can have.
-    /// The first value is the length of the data that was attempt to send
-    /// and the second one is the maximun offers by the datagram based protocol used.
-    MaxPacketSizeExceeded(usize, usize),
+    MaxPacketSizeExceeded,
 
     /// It means that the message could not be sent by the specified `ResourceId`.
     /// This implies that a [`crate::network::NetEvent::Disconnected`] has happened or that
     /// the resource never existed.
     ResourceNotFound,
-
-    /// The resource can not perform the required send operation.
-    /// Usually this is due because it is performing the handshake.
-    ResourceNotAvailable,
 }
 
 /// Returned as a result of [`Remote::receive()`]

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -157,10 +157,7 @@ impl<R: Remote, L: Local> ActionController for Driver<R, L> {
     fn send(&self, endpoint: Endpoint, data: &[u8]) -> SendStatus {
         match endpoint.resource_id().resource_type() {
             ResourceType::Remote => match self.remote_registry.get(endpoint.resource_id()) {
-                Some(remote) => match remote.properties.is_ready() {
-                    true => remote.resource.send(data),
-                    false => SendStatus::ResourceNotAvailable,
-                },
+                Some(remote) => remote.resource.send(data), // Resource always ready at this point
                 None => SendStatus::ResourceNotFound,
             },
             ResourceType::Local => match self.local_registry.get(endpoint.resource_id()) {

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -157,7 +157,10 @@ impl<R: Remote, L: Local> ActionController for Driver<R, L> {
     fn send(&self, endpoint: Endpoint, data: &[u8]) -> SendStatus {
         match endpoint.resource_id().resource_type() {
             ResourceType::Remote => match self.remote_registry.get(endpoint.resource_id()) {
-                Some(remote) => remote.resource.send(data), // Resource always ready at this point
+                Some(remote) => match remote.properties.is_ready() {
+                    true => remote.resource.send(data),
+                    false => SendStatus::ResourceNotAvailable,
+                },
                 None => SendStatus::ResourceNotFound,
             },
             ResourceType::Local => match self.local_registry.get(endpoint.resource_id()) {

--- a/src/network/transport.rs
+++ b/src/network/transport.rs
@@ -68,10 +68,9 @@ impl Transport {
 
     /// Maximum teorical packet payload length available for each transport.
     ///
-    /// Note: For UDP this value *depends* of the OS.
     /// The value returned by this function is the **teorical maximum** and could not be valid for
-    /// all OS (*MacOS* in as an example of this).
-    /// You can ensure your message not exceeds `udp::MAX_COMPATIBLE_UDP_PAYLOAD_LEN` in order to be
+    /// all networks.
+    /// You can ensure your message not exceeds `udp::MAX_INTERNET_PAYLOAD_LEN` in order to be
     /// more cross-platform compatible.
     pub const fn max_message_size(self) -> usize {
         match self {
@@ -80,7 +79,7 @@ impl Transport {
             #[cfg(feature = "tcp")]
             Self::FramedTcp => usize::MAX,
             #[cfg(feature = "udp")]
-            Self::Udp => udp::MAX_PAYLOAD_LEN,
+            Self::Udp => udp::MAX_LOCAL_PAYLOAD_LEN,
             #[cfg(feature = "websocket")]
             Self::Ws => ws::MAX_PAYLOAD_LEN,
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -278,7 +278,7 @@ fn burst(transport: Transport, messages_count: usize) {
 
 #[cfg_attr(feature = "tcp", test_case(Transport::Tcp, BIG_MESSAGE_SIZE))]
 #[cfg_attr(feature = "tcp", test_case(Transport::FramedTcp, BIG_MESSAGE_SIZE))]
-#[cfg_attr(feature = "udp", test_case(Transport::Udp, udp::MAX_COMPATIBLE_PAYLOAD_LEN))]
+#[cfg_attr(feature = "udp", test_case(Transport::Udp, udp::MAX_LOCAL_PAYLOAD_LEN))]
 #[cfg_attr(feature = "websocket", test_case(Transport::Ws, BIG_MESSAGE_SIZE))]
 fn message_size(transport: Transport, message_size: usize) {
     //util::init_logger(LogThread::Disabled); // Enable it for better debugging


### PR DESCRIPTION
- Modified `SendStatus::MaxPacketSizeExceeded`, now it not contains lengths info.
- Renamed `udp::MAX_COMPATIBLE_PAYLOAD_LEN` to `udp::MAX_LOCAL_PAYLOAD_LEN`, value updatedwith `udp::MAX_PAYLOAD_LEN`.
- Removed `udp::MAX_PAYLOAD_LEN`.- Added `udp::MAX_NETWORK_PAYLOAD_LEN`.