### PR TITLE
Removed peer_addr() call used only for logging purposes

### DIFF
--- a/src/adapters/framed_tcp.rs
+++ b/src/adapters/framed_tcp.rs
@@ -62,8 +62,7 @@ impl Remote for RemoteResource {
                 Ok(0) => break ReadStatus::Disconnected,
                 Ok(size) => {
                     let data = &input_buffer[..size];
-                    let addr = self.stream.peer_addr().unwrap();
-                    log::trace!("Decoding data from {}, {} bytes", addr, data.len());
+                    log::trace!("Decoding {} bytes", data.len());
                     self.decoder.borrow_mut().decode(data, |decoded_data| {
                         process_data(decoded_data);
                     });

--- a/src/node.rs
+++ b/src/node.rs
@@ -227,7 +227,6 @@ impl<S> NodeHandler<S> {
     /// Check if the node is running.
     /// Note that the node is running and listening events from its creation,
     /// not only once you call to [`NodeListener::for_each()`].
-    /// Calling this function only will offer the event to the user to be processed.
     pub fn is_running(&self) -> bool {
         self.0.running.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
Sometimes the peer_addr() recovered is set as not connected. Because this method is called only for logging purpose, it can safety removed to avoid connection issues