### PR TITLE
Linux: UDP listen: Receive broadcasts (mimic Windows behavior)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "once_cell",
  "scopeguard",
 ]
@@ -435,6 +435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "message-io"
 version = "0.14.8"
 dependencies = [
@@ -448,8 +457,10 @@ dependencies = [
  "httparse",
  "integer-encoding",
  "lazy_static",
+ "libc",
  "log",
  "mio",
+ "nix",
  "rand",
  "serde",
  "socket2",
@@ -469,6 +480,19 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "static_assertions",
 ]
 
 [[package]]
@@ -731,6 +755,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,15 @@ url = { version = "2.2", optional = true }
 integer-encoding = "3.0.2"
 lazy_static = "1.4.0"
 
+[target.'cfg(target_os = "linux")'.dependencies.nix]
+version = "0.26.2"
+default-features = false
+features = ["socket", "uio", "net"]
+
+[target.'cfg(target_os = "linux")'.dependencies.libc]
+version = "0.2.137"
+default-features = false
+
 [dev-dependencies]
 bincode = "1.3.1"
 criterion = "0.4"

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -62,7 +62,7 @@ pub struct UdpListenConfig {
     /// Enables the socket capabilities to send broadcast messages when the listening socket is
     /// also used for sending with
     /// [`Endpoint::from_listener`](crate::network::Endpoint::from_listener).
-    pub broadcast: bool,
+    pub send_broadcasts: bool,
 
     /// Set value for the `SO_REUSEADDR` option on this socket. This indicates that futher calls to
     /// `bind` may allow reuse of local addresses.
@@ -198,9 +198,7 @@ impl Local for LocalResource {
         if config.reuse_port || multicast.is_some() {
             socket.set_reuse_port(true)?;
         }
-        if config.broadcast {
-            socket.set_broadcast(true)?;
-        }
+        socket.set_broadcast(config.send_broadcasts)?;
 
         if let Some(multicast) = multicast {
             socket.join_multicast_v4(multicast.ip(), &Ipv4Addr::UNSPECIFIED)?;


### PR DESCRIPTION
On Windows, when listening on a specific IP address, you also receive corresponding subnet broadcasts and global broadcasts (Ipv4Addr::BROADCAST) received on the interface matching the IP.

In order to mimic that behavior on Linux, this change adds ingress filters to UDP/Listen so one can listen on Ipv4Addr::UNSPECIFIED but drop any packet that is not received on the specified interface or any of the specified IP addresses.

@lemunozm  As I said in #142 I'm not sure if that's too much code for a too specific problem to be merged upstream. But I'll leave it here for you to decide.
