### PR TITLE
tcp: Add source address option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ features = ["socket", "uio", "net"]
 version = "0.2.137"
 default-features = false
 
+[target.'cfg(unix)'.dependencies.libc]
+version = "0.2.137"
+default-features = false
+
 [dev-dependencies]
 bincode = "1.3.1"
 criterion = "0.4"

--- a/src/adapters/framed_tcp.rs
+++ b/src/adapters/framed_tcp.rs
@@ -24,14 +24,28 @@ const INPUT_BUFFER_SIZE: usize = u16::MAX as usize; // 2^16 - 1
 
 #[derive(Clone, Debug, Default)]
 pub struct FramedTcpConnectConfig {
+    keepalive: Option<TcpKeepalive>,
+}
+
+impl FramedTcpConnectConfig {
     /// Enables TCP keepalive settings on the socket.
-    pub keepalive: Option<TcpKeepalive>,
+    pub fn with_keepalive(mut self, keepalive: TcpKeepalive) -> Self {
+        self.keepalive = Some(keepalive);
+        self
+    }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct FramedTcpListenConfig {
+    keepalive: Option<TcpKeepalive>,
+}
+
+impl FramedTcpListenConfig {
     /// Enables TCP keepalive settings on client connection sockets.
-    pub keepalive: Option<TcpKeepalive>,
+    pub fn with_keepalive(mut self, keepalive: TcpKeepalive) -> Self {
+        self.keepalive = Some(keepalive);
+        self
+    }
 }
 
 pub(crate) struct FramedTcpAdapter;

--- a/src/adapters/tcp.rs
+++ b/src/adapters/tcp.rs
@@ -25,14 +25,28 @@ pub const INPUT_BUFFER_SIZE: usize = u16::MAX as usize; // 2^16 - 1
 
 #[derive(Clone, Debug, Default)]
 pub struct TcpConnectConfig {
+    keepalive: Option<TcpKeepalive>,
+}
+
+impl TcpConnectConfig {
     /// Enables TCP keepalive settings on the socket.
-    pub keepalive: Option<TcpKeepalive>,
+    pub fn with_keepalive(mut self, keepalive: TcpKeepalive) -> Self {
+        self.keepalive = Some(keepalive);
+        self
+    }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct TcpListenConfig {
+    keepalive: Option<TcpKeepalive>,
+}
+
+impl TcpListenConfig {
     /// Enables TCP keepalive settings on client connection sockets.
-    pub keepalive: Option<TcpKeepalive>,
+    pub fn with_keepalive(mut self, keepalive: TcpKeepalive) -> Self {
+        self.keepalive = Some(keepalive);
+        self
+    }
 }
 
 pub(crate) struct TcpAdapter;

--- a/src/adapters/tcp.rs
+++ b/src/adapters/tcp.rs
@@ -7,7 +7,7 @@ use crate::network::{RemoteAddr, Readiness, TransportConnect, TransportListen};
 use mio::net::{TcpListener, TcpStream};
 use mio::event::{Source};
 
-use socket2::{Socket, TcpKeepalive};
+use socket2::{Socket, Domain, TcpKeepalive, Type, Protocol};
 
 use std::net::{SocketAddr};
 use std::io::{self, ErrorKind, Read, Write};
@@ -25,6 +25,7 @@ pub const INPUT_BUFFER_SIZE: usize = u16::MAX as usize; // 2^16 - 1
 
 #[derive(Clone, Debug, Default)]
 pub struct TcpConnectConfig {
+    source_address: Option<SocketAddr>,
     keepalive: Option<TcpKeepalive>,
 }
 
@@ -32,6 +33,12 @@ impl TcpConnectConfig {
     /// Enables TCP keepalive settings on the socket.
     pub fn with_keepalive(mut self, keepalive: TcpKeepalive) -> Self {
         self.keepalive = Some(keepalive);
+        self
+    }
+
+    /// Specify the source address and port.
+    pub fn with_source_address(mut self, source_address: SocketAddr) -> Self {
+        self.source_address = Some(source_address);
         self
     }
 }
@@ -76,7 +83,30 @@ impl Remote for RemoteResource {
             _ => panic!("Internal error: Got wrong config"),
         };
         let peer_addr = *remote_addr.socket_addr();
-        let stream = TcpStream::connect(peer_addr)?;
+
+        let socket = Socket::new(
+            match peer_addr {
+                SocketAddr::V4 { .. } => Domain::IPV4,
+                SocketAddr::V6 { .. } => Domain::IPV6,
+            },
+            Type::STREAM,
+            Some(Protocol::TCP),
+        )?;
+        socket.set_nonblocking(true)?;
+
+        if let Some(source_address) = config.source_address {
+            socket.bind(&source_address.into())?;
+        }
+
+        match socket.connect(&peer_addr.into()) {
+            #[cfg(unix)]
+            Err(e) if e.raw_os_error() != Some(libc::EINPROGRESS) => return Err(e),
+            #[cfg(windows)]
+            Err(e) if e.kind() != io::ErrorKind::WouldBlock => return Err(e),
+            _ => {}
+        }
+
+        let stream = TcpStream::from_std(socket.into());
         let local_addr = stream.local_addr()?;
         Ok(ConnectionInfo {
             remote: Self { stream, keepalive: config.keepalive },

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -39,22 +39,41 @@ pub const MAX_LOCAL_PAYLOAD_LEN: usize = 9216 - 20 - 8;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct UdpConnectConfig {
+    source_address: SocketAddr,
+    broadcast: bool,
+    reuse_address: bool,
+    reuse_port: bool,
+}
+
+impl UdpConnectConfig {
     /// Specify the source address and port.
-    pub source_address: SocketAddr,
+    pub fn with_source_address(mut self, addr: SocketAddr) -> Self {
+        self.source_address = addr;
+        self
+    }
 
     /// Enables the socket capabilities to send broadcast messages.
-    pub broadcast: bool,
+    pub fn with_broadcast(mut self) -> Self {
+        self.broadcast = true;
+        self
+    }
 
     /// Set value for the `SO_REUSEADDR` option on this socket. This indicates that futher calls to
     /// `bind` may allow reuse of local addresses. For IPv4 sockets this means that a socket may
     /// bind even when there’s a socket already listening on this port.
-    pub reuse_address: bool,
+    pub fn with_reuse_address(mut self) -> Self {
+        self.reuse_address = true;
+        self
+    }
 
     /// Set value for the `SO_REUSEPORT` option on this socket. This indicates that further calls
     /// to `bind` may allow reuse of local addresses. For IPv4 sockets this means that a socket may
     /// bind even when there’s a socket already listening on this port. This option is always-on on
     /// Windows and cannot be configured.
-    pub reuse_port: bool,
+    pub fn with_reuse_port(mut self) -> Self {
+        self.reuse_port = true;
+        self
+    }
 }
 
 impl Default for UdpConnectConfig {
@@ -70,26 +89,45 @@ impl Default for UdpConnectConfig {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
 pub struct UdpListenConfig {
+    send_broadcasts: bool,
+    receive_broadcasts: bool,
+    reuse_address: bool,
+    reuse_port: bool,
+}
+
+impl UdpListenConfig {
     /// Enables the socket capabilities to send broadcast messages when the listening socket is
     /// also used for sending with
     /// [`Endpoint::from_listener`](crate::network::Endpoint::from_listener).
-    pub send_broadcasts: bool,
+    pub fn with_send_broadcasts(mut self) -> Self {
+        self.send_broadcasts = true;
+        self
+    }
 
     /// On Windows, when listening on a specific IP address, the sockets also receives
     /// corresponding subnet broadcasts and global broadcasts ([`std::net::Ipv4Addr::BROADCAST`])
     /// received on the interface matching the IP.  When this option is set, message-io mimics this
     /// behavior on Linux.
-    pub receive_broadcasts: bool,
+    pub fn with_receive_broadcasts(mut self) -> Self {
+        self.receive_broadcasts = true;
+        self
+    }
 
     /// Set value for the `SO_REUSEADDR` option on this socket. This indicates that futher calls to
     /// `bind` may allow reuse of local addresses.
-    pub reuse_address: bool,
+    pub fn with_reuse_address(mut self) -> Self {
+        self.reuse_address = true;
+        self
+    }
 
     /// Set value for the `SO_REUSEPORT` option on this socket. This indicates that further calls
     /// to `bind` may allow reuse of local addresses. For IPv4 sockets this means that a socket may
     /// bind even when there’s a socket already listening on this port. This option is always-on
     /// on Windows and cannot be configured.
-    pub reuse_port: bool,
+    pub fn with_reuse_port(mut self) -> Self {
+        self.reuse_port = true;
+        self
+    }
 }
 
 pub(crate) struct UdpAdapter;

--- a/src/network.rs
+++ b/src/network.rs
@@ -126,7 +126,7 @@ impl NetworkController {
     /// let (handler, listener) = node::split();
     /// handler.signals().send_with_timer((), std::time::Duration::from_secs(1));
     ///
-    /// let config = UdpConnectConfig { broadcast: true, ..Default::default() };
+    /// let config = UdpConnectConfig::default().with_broadcast();
     /// let addr = "255.255.255.255:7777";
     /// let (conn_endpoint, _) = handler.network().connect_with(TransportConnect::Udp(config), addr).unwrap();
     /// // The socket could not be able to send yet.
@@ -226,7 +226,7 @@ impl NetworkController {
     /// let (handler, listener) = node::split();
     /// handler.signals().send_with_timer((), std::time::Duration::from_secs(1));
     ///
-    /// let config = UdpConnectConfig { broadcast: true, ..Default::default() };
+    /// let config = UdpConnectConfig::default().with_broadcast();
     /// let addr = "255.255.255.255:7777";
     /// match handler.network().connect_sync_with(TransportConnect::Udp(config), addr) {
     ///     Ok((endpoint, _)) => {


### PR DESCRIPTION
This option allows to specify the source address and port for outgoing
TCP connections.

Depends on #153 