### PR TITLE
Fix compile error: Make IOV live longer

### DIFF
--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -197,7 +197,7 @@ impl Remote for RemoteResource {
                 }
                 Err(err) => {
                     log::error!("UDP receive error: {}", err);
-                    break ReadStatus::WaitNextEvent; // Should not happen
+                    break ReadStatus::WaitNextEvent // Should not happen
                 }
             }
         }

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -394,7 +394,7 @@ impl Local for LocalResource {
         if let Some(multicast) = multicast {
             socket.join_multicast_v4(multicast.ip(), &Ipv4Addr::UNSPECIFIED)?;
             socket.bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, addr.port()).into())?;
-        } 
+        }
         else {
             socket.bind(&addr.into())?;
         }

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -386,7 +386,8 @@ impl Local for LocalResource {
                     Some(ingress_addresses)
                 }
             }
-        } else {
+        } 
+        else {
             None
         };
 

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -193,7 +193,7 @@ impl Remote for RemoteResource {
                 }
                 Err(ref err) if err.kind() == ErrorKind::ConnectionRefused => {
                     // Avoid ICMP generated error to be logged
-                    break ReadStatus::WaitNextEvent;
+                    break ReadStatus::WaitNextEvent
                 }
                 Err(err) => {
                     log::error!("UDP receive error: {}", err);

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -417,7 +417,7 @@ impl Local for LocalResource {
         #[cfg(target_os = "linux")]
         if let Some(ingress_addresses) = &self.ingress_addresses {
             self.accept_filtered(ingress_addresses, accept_remote);
-            return;
+            return
         }
 
         let buffer: MaybeUninit<[u8; MAX_LOCAL_PAYLOAD_LEN]> = MaybeUninit::uninit();

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -262,7 +262,7 @@ impl LocalResource {
                     };
 
                     if !ingress_addresses.contains(&ingress_ip) {
-                        continue;
+                        continue
                     }
 
                     fn convert_sockaddr(addr: SockaddrStorage) -> Option<SocketAddr> {

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -386,7 +386,7 @@ impl Local for LocalResource {
                     Some(ingress_addresses)
                 }
             }
-        } 
+        }
         else {
             None
         };

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -267,7 +267,7 @@ impl LocalResource {
 
                     fn convert_sockaddr(addr: SockaddrStorage) -> Option<SocketAddr> {
                         if let Some(addr) = addr.as_sockaddr_in() {
-                            return Some(SocketAddr::V4((*addr).into()));
+                            return Some(SocketAddr::V4((*addr).into()))
                         }
                         if let Some(addr) = addr.as_sockaddr_in6() {
                             return Some(SocketAddr::V6((*addr).into()));

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -394,7 +394,8 @@ impl Local for LocalResource {
         if let Some(multicast) = multicast {
             socket.join_multicast_v4(multicast.ip(), &Ipv4Addr::UNSPECIFIED)?;
             socket.bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, addr.port()).into())?;
-        } else {
+        } 
+        else {
             socket.bind(&addr.into())?;
         }
 

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -270,7 +270,7 @@ impl LocalResource {
                             return Some(SocketAddr::V4((*addr).into()))
                         }
                         if let Some(addr) = addr.as_sockaddr_in6() {
-                            return Some(SocketAddr::V6((*addr).into()));
+                            return Some(SocketAddr::V6((*addr).into()))
                         }
                         None
                     }

--- a/src/adapters/udp.rs
+++ b/src/adapters/udp.rs
@@ -464,7 +464,7 @@ fn send_packet(data: &[u8], send_method: impl Fn(&[u8]) -> io::Result<usize>) ->
             }
             Err(err) => {
                 log::error!("UDP send error: {}", err);
-                break SendStatus::ResourceNotFound; // should not happen
+                break SendStatus::ResourceNotFound // should not happen
             }
         }
     }


### PR DESCRIPTION
Fixes a compile error that I ran into today after running `cargo update`, where it complains that `io::IoSliceMut::new(&mut input_buffer)]` doesn't live long enough, so I moved it into its own mutable variable, named "iov" to solve it.