### PR TITLE
Fix Tungstenite build error caused by the URL feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,9 +898,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam-utils = "0.8"
 log = "0.4"
 strum = { version = "0.24", features = ["derive"] }
 socket2 = { version = "0.5.1", features = ["all"], optional = true}
-tungstenite = { version = ">=0.20.1", optional = true }
+tungstenite = { version = ">=0.22.0", features = ["url"], optional = true }
 url = { version = "2.2", optional = true }
 integer-encoding = "3.0.2"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Since tungstenite 0.22.0, support for url::Url has become an optional feature, which breaks message-io builds. This commit updates tungstenite to versions greater than or equal to 0.22.0 and requires the URL feature to fix builds.

Fixes #173.