### PR TITLE
docs: fix typo in basic concepts guide

### DIFF
--- a/docs/basic_concepts.md
+++ b/docs/basic_concepts.md
@@ -1,7 +1,7 @@
 # Basic concepts
 The main `message-io` entity is the **node**.
 It is in charge of managing the different connections, performing actions over them and offering
-the events comming from the network or by the own node (called signals).
+the events coming from the network or by the own node (called signals).
 
 <p align="center">
   <img src="https://docs.google.com/drawings/d/e/2PACX-1vQxs3w6bgIL1Qq600Q0IopWiKvvlKdj9KC7rUuF9Der6sN2UtzYrmn81DPEbRNFmBlEkE1qvDGxwc75/pub?w=890&h=617"/>


### PR DESCRIPTION
Fixes a small spelling typo in the basic concepts guide: `comming` -> `coming`.

This PR was made using the GitHub API without cloning the repository locally.